### PR TITLE
Update build-configuration.md

### DIFF
--- a/docs/build-configuration.md
+++ b/docs/build-configuration.md
@@ -60,7 +60,7 @@ List of BuckleScript/Reason dependencies. Just like `package.json`'s dependencie
 
 ### reason, refmt
 
-`reason` config is rnabled by default. To turn on JSX for [ReasonReact](https://reasonml.github.io/reason-react/), specify:
+`reason` config is enabled by default. To turn on JSX for [ReasonReact](https://reasonml.github.io/reason-react/), specify:
 
 ```json
 {


### PR DESCRIPTION
Fix minor typo. 

Also, the paragraph in the "warnings" section references warning `32`, but it's not included in the corresponding example, which is a little confusing.