### PR TITLE
Fix "add yours" button in users page

### DIFF
--- a/website/pages/en/built-with-bucklescript.js
+++ b/website/pages/en/built-with-bucklescript.js
@@ -31,7 +31,7 @@ class Users extends React.Component {
               {showcase}
             </div>
             <a
-              href="https://github.com/reasonml/reason-react/edit/master/website/siteConfig.js"
+              href="https://github.com/BuckleScript/bucklescript.github.io/edit/source/website/siteConfig.js"
               className="button addCompanyButton"
             >
               Add yours


### PR DESCRIPTION
The add yours button was linked to the reason-react website.