### PR TITLE
Add button that allow to toggle between Ocaml/Reason syntaxes

### DIFF
--- a/docs/bind-to-global-values.md
+++ b/docs/bind-to-global-values.md
@@ -15,7 +15,7 @@ external setTimeout : (unit -> unit) -> int -> float = "setTimeout" [@@bs.val]
 external clearTimeout : float -> unit = "clearTimeout" [@@bs.val]
 ```
 
-Reason syntax:
+
 
 ```reason
 [@bs.val] external setTimeout : (unit => unit, int) => float = "setTimeout";
@@ -38,7 +38,7 @@ When the name you're using on the BS side matches the JS value you're modeling, 
 external clearTimeout : float -> unit = "" [@@bs.val]
 ```
 
-Reason syntax:
+
 
 ```reason
 [@bs.val] external clearTimeout : float => unit = "";
@@ -56,7 +56,7 @@ external setTimeout : (unit -> unit) -> int -> timerId = "setTimeout" [@@bs.val]
 external clearTimeout : timerId -> unit = "clearTimeout" [@@bs.val]
 ```
 
-Reason syntax:
+
 
 ```reason
 type timerId;
@@ -79,7 +79,7 @@ external random: unit -> float = "random" [@@bs.val][@@bs.scope "Math"]
 let someNumber = random ()
 ```
 
-Reason syntax:
+
 
 ```reason
 [@bs.scope "Math"] [@bs.val] external random : unit => float = "random";
@@ -92,7 +92,7 @@ you can bind to an arbitrarily deep object by passing a tuple to `bs.scope`:
 external length: int = "length" [@@bs.val][@@bs.scope "window", "ancestorOrigins", "ancestorOrigins"]
 ```
 
-Reason syntax:
+
 
 ```reason
 [@bs.val] [@bs.scope ("window", "ancestorOrigins", "ancestorOrigins")] external length : int = "length";

--- a/docs/class.md
+++ b/docs/class.md
@@ -13,7 +13,7 @@ external createDate : unit -> t = "Date" [@@bs.new]
 let date = createDate ()
 ```
 
-Reason syntax:
+
 
 ```reason
 type t;
@@ -36,7 +36,7 @@ external book : unit -> t = "Book" [@@bs.new] [@@bs.module]
 let bookInstance = book ()
 ```
 
-Reason syntax:
+
 
 ```reason
 type t;
@@ -67,7 +67,7 @@ end [@bs]
 type rect = _rect Js.t
 ```
 
-Reason syntax:
+
 
 ```reason
 class type _rect =

--- a/docs/embed-raw-javascript.md
+++ b/docs/embed-raw-javascript.md
@@ -15,7 +15,7 @@ let add = [%raw {|
 let _ = Js.log (add 1 2)
 ```
 
-Reason syntax:
+
 
 ```reason
 let add = [%raw {|
@@ -38,7 +38,7 @@ The `{|foo|}` syntax stands for OCaml/BuckleScript/Reason's multi-line, "quoted 
 let f = [%raw "function() {return 1}"]
 ```
 
-Reason syntax:
+
 
 ```reason
 [%%raw "var a = 1"];
@@ -52,7 +52,7 @@ You can also pass a function declaration with a string body in `raw`:
 let f: (int -> int -> int) = [%raw fun a b -> "{return a + b}"]
 ```
 
-Reason syntax:
+
 
 ```reason
 let f: (int, int) => int = [%raw (a, b) => "{return a + b}"];
@@ -79,7 +79,7 @@ let f x y =
   x + y
 ```
 
-Reason syntax:
+
 
 ```reason
 let f = (x, y) => {

--- a/docs/exceptions.md
+++ b/docs/exceptions.md
@@ -16,7 +16,7 @@ with
   | None -> Js.log "An unknown error occurred"
 ```
 
-Reason syntax:
+
 
 ```reason
 try (
@@ -51,7 +51,7 @@ let _ =
   )
 ```
 
-Reason syntax:
+
 
 ```reason
 exception UnhandledPromise;

--- a/docs/fast-pipe.md
+++ b/docs/fast-pipe.md
@@ -8,7 +8,7 @@ BuckleScript and Reason have a special `|.` syntax for dealing with various situ
 
 `a |. foo b` is equal to `foo a b`. The operator takes the item on the left and put it as the first argument of the item on the right. Great for building pipelines of data processing: `a |. foo b |. bar` is equal to `bar(foo a b)`.
 
-Reason syntax: `a |. foo(b) |. bar` is equal to `bar(foo(a, b))`.
+ `a |. foo(b) |. bar` is equal to `bar(foo(a, b))`.
 
 ## JS Method Chaining
 
@@ -32,7 +32,7 @@ external setWaitDuration: request -> int -> request = "" [@@bs.send]
 external send: request -> unit = "" [@@bs.send]
 ```
 
-Reason syntax:
+
 
 ```reason
 [@bs.send] external map : (array('a), 'a => 'b) => array('b) = "";
@@ -76,7 +76,7 @@ let middle = getMiddle myData
 let right = getRight myData
 ```
 
-Reason syntax:
+
 
 ```reason
 let left = getLeft(myData);
@@ -99,7 +99,7 @@ Set.add mySet 2
 Set.remove mySet 1
 ```
 
-Reason syntax:
+
 
 ```reason
 let mySet = Set.make();
@@ -119,7 +119,7 @@ let () = mySet |. [
 ]
 ```
 
-Reason syntax:
+
 
 ```reason
 let mySet = Set.make();

--- a/docs/function.md
+++ b/docs/function.md
@@ -9,7 +9,7 @@ external encodeURI: string -> string = "encodeURI" [@@bs.val]
 let result = encodeURI "hello"
 ```
 
-Reason syntax:
+
 
 ```reason
 [@bs.val] external encodeURI : string => string = "encodeURI";
@@ -39,7 +39,7 @@ let _ = draw ~x:10 ~y:20 ~border:true ()
 let _ = draw ~x:10 ~y:20 ()
 ```
 
-Reason syntax:
+
 
 ```reason
 [@bs.val] external draw : (~x: int, ~y: int, ~border: bool=?, unit) => unit = "";
@@ -71,7 +71,7 @@ external doc: document = "document" [@@bs.val]
 let el = getElementById doc "myId"
 ```
 
-Reason syntax:
+
 
 ```reason
 type document; /* abstract type for a document object */
@@ -102,7 +102,7 @@ external join : string array -> string = "" [@@bs.module "path"] [@@bs.splice]
 let v = join [| "a"; "b"|]
 ```
 
-Reason syntax:
+
 
 ```reason
 [@bs.module "path"] [@bs.splice] external join : array(string) => string = "";
@@ -132,7 +132,7 @@ external drawDog: giveName:string -> unit = "draw" [@@bs.module "Drawing"]
 external draw : string -> useRandomAnimal:bool -> unit = "draw" [@@bs.module "Drawing"]
 ```
 
-Reason syntax:
+
 
 ```reason
 [@bs.module "Drawing"] external drawCat : unit => unit = "draw";
@@ -173,7 +173,7 @@ let _ = padLeft "Hello World" (`Int 4)
 let _ = padLeft "Hello World" (`Str "Message from BS: ")
 ```
 
-Reason syntax:
+
 
 ```reason
 [@bs.val]
@@ -212,7 +212,7 @@ external readFileSync :
 let _ = readFileSync ~name:"xx.txt" `useAscii
 ```
 
-Reason syntax:
+
 
 ```reason
 [@bs.module "fs"]
@@ -253,7 +253,7 @@ external test_int_type :
 let _ = test_int_type `in_bin
 ```
 
-Reason syntax:
+
 
 ```reason
 [@bs.val]
@@ -291,7 +291,7 @@ let register rl =
   |. on (`line (fun line -> print_endline line))
 ```
 
-Reason syntax:
+
 
 ```reason
 type readline;
@@ -341,7 +341,7 @@ let () = process_on_exit (fun exit_code ->
 )
 ```
 
-Reason syntax:
+
 
 ```reason
 [@bs.val]
@@ -376,7 +376,7 @@ let addFive = add 5
 let twelve = addFive 3 4
 ```
 
-Reason syntax:
+
 
 ```reason
 let add = (x, y, z) => x + y + z;
@@ -392,7 +392,7 @@ val addFive: int -> int -> int
 val twelve: int
 ```
 
-Reason syntax:
+
 
 ```reason
 let add: (int, int, int) => int;
@@ -429,7 +429,7 @@ external setTimeout : (unit -> unit [@bs]) -> int -> timerId = "setTimeout" [@@b
 let id = setTimeout (fun [@bs] () -> Js.log "hello") 1000
 ```
 
-Reason syntax:
+
 
 ```reason
 type timerId;
@@ -447,7 +447,7 @@ let add = fun [@bs] x y z -> x + y + z
 let addFiveOops = add 5
 ```
 
-Reason syntax:
+
 
 ```reason
 let add = (. x, y, z) => x + y + z;
@@ -477,7 +477,7 @@ external map : 'a array -> ('a -> 'b [@bs.uncurry]) -> 'b array = "" [@@bs.send]
 let _ = map [|1; 2; 3|] (fun x -> x+ 1)
 ```
 
-Reason syntax:
+
 
 ```reason
 [@bs.send] external map : (array('a), [@bs.uncurry] ('a => 'b)) => array('b) = "";
@@ -492,7 +492,7 @@ If you try to do this:
 let id : ('a -> 'a [@bs]) = ((fun v -> v) [@bs])
 ```
 
-Reason syntax:
+
 
 ```reason
 let id: (. 'a) => 'a = (. v) => v;
@@ -513,7 +513,7 @@ The simplest solution is in most cases to just not export it, by adding an inter
 let _ = map (fun v -> id v [@bs])
 ```
 
-Reason syntax:
+
 
 ```reason
 map(v => id(. v));
@@ -549,7 +549,7 @@ let _ =
   end
 ```
 
-Reason syntax:
+
 
 ```reason
 type x;

--- a/docs/generate-converters-accessors.md
+++ b/docs/generate-converters-accessors.md
@@ -16,7 +16,7 @@ type action =
   [@@bs.deriving accessors]
 ```
 
-Reason syntax:
+
 
 ```reason
 [@bs.deriving accessors]
@@ -54,7 +54,7 @@ exports.cancel = cancel;
 let s = submit "hello" (* gives Submit "hello" *)
 ```
 
-Reason syntax:
+
 
 ```reason
 let s = submit("hello"); /* gives Submit("hello") */
@@ -76,7 +76,7 @@ type coordinates = {
 } [@@bs.deriving jsConverter]
 ```
 
-Reason syntax:
+
 
 ```reason
 [@bs.deriving jsConverter]
@@ -94,7 +94,7 @@ val coordinatesToJs : coordinates -> <x : int ; y : int > Js.t
 val coordinatesFromJs : < x: int ; y : int ; .. > Js.t -> coordinates
 ```
 
-Reason syntax:
+
 
 ```reason
 let coordinatesToJs: coordinates => {. "x": int, "y": int};
@@ -115,7 +115,7 @@ This exports a `jsCoordinates` JS object (not a record!) for JS files to use:
 let jsCoordinates = coordinatesToJs {x = 1; y = 2}
 ```
 
-Reason syntax:
+
 
 ```reason
 let jsCoordinates = coordinatesToJs({x: 1, y: 2});
@@ -127,7 +127,7 @@ This binds to a `jsCoordinates` record (not a JS object!) that exists on the JS 
 external jsCoordinates: coordinates = "jsCoordinates" [@@bs.module "myGame"]
 ```
 
-Reason syntax:
+
 
 ```reason
 [@bs.module "myGame"] external jsCoordinates : coordinates = "jsCoordinates";
@@ -144,7 +144,7 @@ type coordinates = {
 } [@@bs.deriving {jsConverter = newType}]
 ```
 
-Reason syntax:
+
 
 ```reason
 [@bs.deriving {jsConverter: newType}]
@@ -162,7 +162,7 @@ val coordinatesToJs : coordinates -> abs_coordinates
 val coordinatesFromJs : abs_coordinates -> coordinates
 ```
 
-Reason syntax:
+
 
 ```reason
 let coordinatesToJs: coordinates => abs_coordinates;
@@ -184,7 +184,7 @@ let jsCoords = coordinatesToJs myCoordinates
 let x = jsCoords##x (* disallowed! Don't access the object's internal details *)
 ```
 
-Reason syntax:
+
 
 ```reason
 let myCoordinates = {
@@ -211,7 +211,7 @@ type fruit =
   [@@bs.deriving jsConverter]
 ```
 
-Reason syntax:
+
 
 ```reason
 [@bs.deriving jsConverter]
@@ -230,7 +230,7 @@ val fruitToJs : fruit -> int
 val fruitFromJs : int -> fruit option
 ```
 
-Reason syntax:
+
 
 ```reason
 let fruitToJs: fruit => int;
@@ -261,7 +261,7 @@ let _ = match fruitFromJs 100 with
 | _ -> Js.log "received something wrong from the JS side"
 ```
 
-Reason syntax:
+
 
 ```reason
 [@bs.deriving jsConverter]
@@ -293,7 +293,7 @@ type fruit =
   [@@bs.deriving {jsConverter = newType}]
 ```
 
-Reason syntax:
+
 
 ```reason
 [@bs.deriving {jsConverter: newType}]
@@ -311,7 +311,7 @@ val fruitToJs : fruit -> abs_fruit
 val fruitFromJs : abs_fruit -> fruit
 ```
 
-Reason syntax:
+
 
 ```reason
 let fruitToJs: fruit => abs_fruit;
@@ -338,7 +338,7 @@ let kiwi = fruitFromJs jsKiwi
 let error = fruitFromJs 100 (* nope, can't take a random int *)
 ```
 
-Reason syntax:
+
 
 ```reason
 [@bs.deriving {jsConverter: newType}]
@@ -372,7 +372,7 @@ let appleString = fruitToJs `Apple (* "Apple" *)
 let kiwiString = fruitToJs `Kiwi (* "miniCoconut" *)
 ```
 
-Reason syntax:
+
 
 ```reason
 [@bs.deriving jsConverter]
@@ -408,7 +408,7 @@ type cord = {
 It will generate such functions
 
 ```ocaml
-type cord 
+type cord
 val cord : a:int -> b:int -> t  (* maker *)
 val x : cord -> int (* getter *)
 val y : cord -> int (* getter *)
@@ -420,8 +420,8 @@ Since now `cord` is completey abstract type, for BuckleScript backend, we compil
 ```ocaml
 let u = cord ~x:2 ~y:3
 
-let () = 
-  let x, y = u |. x, u |. y in 
+let () =
+  let x, y = u |. x, u |. y in
   u |. ySet (x + y)
 ```
 Will generate such code
@@ -446,14 +446,14 @@ We can customize the label to be different names, suppose we change the type def
 ```ocaml
 type cord = {
   x : int;
-  mutable y : int [@bs.as "Content-Type"]; 
+  mutable y : int [@bs.as "Content-Type"];
 } [@@bs.deriving abstract]
 
 
 let u = cord ~x:2 ~y:3
 
-let () = 
-  let x, y = u |. x, u |. y in 
+let () =
+  let x, y = u |. x, u |. y in
   u |. ySet (x + y)
 ```
 
@@ -478,8 +478,8 @@ We can also mark some labels optional, so that it does not need to be supplied a
 
 ```ocaml
 type cord = {
-  mutable x : int [@bs.optional]; 
-  y : int ; 
+  mutable x : int [@bs.optional];
+  y : int ;
 } [@@bs.deriving abstract]
 
 ```
@@ -488,21 +488,21 @@ It will generate such functions:
 
 ```ocaml
 type cord
-val cord : ?x:int -> y:int -> unit -> cord 
-val x : cord -> int option 
-val xSet : cord -> int -> unit 
-val y : cord -> int 
+val cord : ?x:int -> y:int -> unit -> cord
+val x : cord -> int option
+val xSet : cord -> int -> unit
+val y : cord -> int
 ```
 
 ```ocaml
 let u = cord  ~y:3 ()
 
-let () = 
-  let x, y = u |. x, u |. y in 
-  match x with 
-  | None -> 
+let () =
+  let x, y = u |. x, u |. y in
+  match x with
+  | None ->
 	u |. xSet y
-  | Some x -> 
+  | Some x ->
   	u |. xSet (x + y )
 ```
 
@@ -529,9 +529,9 @@ if (x !== undefined) {
 
 ```ocaml
 type cord = {
-  mutable x : int  [@bs.optional]; 
-  y : int ; 
-} [@@bs.deriving abstract] 
+  mutable x : int  [@bs.optional];
+  y : int ;
+} [@@bs.deriving abstract]
 ```
 
 Will generate such signatures
@@ -539,8 +539,8 @@ Will generate such signatures
 ```ocaml
 val cord : ?x:int -> y:int -> unit -> cord
 val x : cord -> int option
-val xSet : cord -> int -> unit 
-val y : cord -> int 
+val xSet : cord -> int -> unit
+val y : cord -> int
 ```
 
 We can make it a bit more restrictive when exposing to clients by removing `mutable` in `x`:
@@ -553,9 +553,9 @@ type cord = {
 
 Will generate such signatures:
 ```ocaml
-val cord : ?x:int -> y: int -> unit -> cord  
+val cord : ?x:int -> y: int -> unit -> cord
 val x : cord -> int option
-val y : cord -> int 
+val y : cord -> int
 ```
 
 More restrictive by marking the constructor `private`:
@@ -567,5 +567,5 @@ type cord = private { x : int [@bs.optional]; y : int} [@@bs.deriving abstract]
 Will generate such signatures:
 ```ocaml
 val x : cord -> int option
-val y : cord -> int 
+val y : cord -> int
 ```

--- a/docs/import-export.md
+++ b/docs/import-export.md
@@ -62,7 +62,7 @@ external dirname: string -> string = "dirname" [@@bs.module "path"]
 let root = dirname "/User/chenglou"
 ```
 
-Reason syntax:
+
 
 ```reason
 [@bs.module "path"] external dirname : string => string = "dirname";
@@ -87,7 +87,7 @@ external leftPad: string -> int -> string = "./leftPad" [@@bs.module]
 let paddedResult = leftPad "hi" 5
 ```
 
-Reason syntax:
+
 
 ```reason
 [@bs.module] external leftPad : string => int => string = "./leftPad";
@@ -110,7 +110,7 @@ external studentName: string = "default" [@@bs.module "./student"]
 let _ = Js.log studentName
 ```
 
-Reason syntax:
+
 
 ```reason
 [@bs.module "./student"] external studentName : string = "default";
@@ -132,7 +132,7 @@ When the name you're using on the BS side matches the name of the JS value, you 
 external dirname: string -> string = "" [@@bs.module "path"]
 ```
 
-Reason syntax:
+
 
 ```reason
 [@bs.module "path"] external dirname : string => string = "";

--- a/docs/interop-cheatsheet.md
+++ b/docs/interop-cheatsheet.md
@@ -12,7 +12,7 @@ let add = [%raw "a + b"]
 let myFunction = [%raw fun a b -> "return a + b"]
 ```
 
-Reason syntax:
+
 
 ```reason
 let add = [%raw "a + b"];
@@ -30,7 +30,7 @@ let world = "world"
 let helloWorld = {j|hello, $world|j}
 ```
 
-Reason syntax:
+
 
 ```reason
 Js.log({js|你好，
@@ -46,7 +46,7 @@ let helloWorld = {j|hello, $world|j};
 external setTimeout : (unit -> unit) -> int -> float = "setTimeout" [@@bs.val]
 ```
 
-Reason syntax:
+
 
 ```reason
 [@bs.val] external setTimeout : (unit => unit, int) => float = "setTimeout";
@@ -61,7 +61,7 @@ let someNumber = random ()
 external length: int = "length" [@@bs.val][@@bs.scope "window", "location", "ancestorOrigins"]
 ```
 
-Reason syntax:
+
 
 ```reason
 [@bs.val] [@bs.scope "Math"] external random : unit => float = "random";
@@ -81,7 +81,7 @@ let result2: int Js.Nullable.t  = Js.Nullable.fromOption (Some 10)
 let result3: int option  = Js.Nullable.toOption (Js.Nullable.return 10)
 ```
 
-Reason syntax:
+
 
 ```reason
 let jsNull = Js.Nullable.null;
@@ -98,7 +98,7 @@ Directly convert from `Js.Nullable.t` to `option`:
 external getElementById : string -> element option = "getElementById" [@@bs.scope "document"][@@bs.return nullable]
 ```
 
-Reason syntax:
+
 
 ```reason
 [@bs.scope "document"] [@bs.return nullable]
@@ -114,7 +114,7 @@ let myMap = Js.Dict.empty ()
 let _ = Js.Dict.set myMap "Allison" 10
 ```
 
-Reason syntax:
+
 
 ```reason
 let myMap = Js.Dict.empty();
@@ -137,7 +137,7 @@ let _ = john##job #= "Accountant"
 let nick = john##getNickname ()
 ```
 
-Reason syntax:
+
 
 ```reason
 type person = {
@@ -164,7 +164,7 @@ let bucklescript = [%bs.obj {
 let name = bucklescript##info##author
 ```
 
-Reason syntax:
+
 
 ```reason
 let bucklescript = {
@@ -188,7 +188,7 @@ let c1 = makeConfig ~high:3 ()
 let low: int Js.undefined = c1##low
 ```
 
-Reason syntax:
+
 
 ```reason
 [@bs.obj]
@@ -209,7 +209,7 @@ stream##_open (* open *)
 stream##_MAX_LENGTH (* MAX_LENGTH *)
 ```
 
-Reason syntax:
+
 
 ```reason
 stream##_open /* open */
@@ -226,7 +226,7 @@ type textarea
 external setName : textarea -> string -> unit = "name" [@@bs.set]
 ```
 
-Reason syntax:
+
 
 ```reason
 type t;
@@ -243,7 +243,7 @@ type t
 external createDate : unit -> t = "Date" [@@bs.new]
 ```
 
-Reason syntax:
+
 
 ```reason
 type t;
@@ -265,7 +265,7 @@ let () = [|1; 2; 3|]
   |. Js.log
 ```
 
-Reason syntax:
+
 
 ```reason
 [@bs.send] external map : (array('a), 'a => 'b) => array('b) = "";
@@ -284,7 +284,7 @@ Reason syntax:
 external join : string array -> string = "" [@@bs.module "path"] [@@bs.splice]
 ```
 
-Reason syntax:
+
 
 ```reason
 [@bs.module "path"] [@bs.splice]
@@ -298,7 +298,7 @@ external drawCat: unit -> unit = "draw" [@@bs.module "Drawing"]
 external drawDog: giveName:string -> unit = "draw" [@@bs.module "Drawing"]
 ```
 
-Reason syntax:
+
 
 ```reason
 [@bs.module "Drawing"] external drawCat : unit => unit = "draw";
@@ -317,7 +317,7 @@ external padLeft :
 let _ = padLeft "Hello World" (`Int 4)
 ```
 
-Reason syntax:
+
 
 ```reason
 [@bs.val] external padLeft : (
@@ -338,7 +338,7 @@ let add = fun [@bs] x y z -> x + y + z
 let six = (add 1 2 3) [@bs]
 ```
 
-Reason syntax:
+
 
 ```reason
 let add = [@bs] ((x, y, z) => x + y + z);
@@ -351,7 +351,7 @@ let six = [@bs] add(1, 2, 3);
 external dirname: string -> string = "dirname" [@@bs.module "path"]
 ```
 
-Reason syntax:
+
 
 ```reason
 [@bs.module "path"] external dirname : string => string = "dirname";
@@ -363,7 +363,7 @@ Reason syntax:
 external leftPad: string -> int -> string = "./leftPad" [@@bs.module]
 ```
 
-Reason syntax:
+
 
 ```reason
 [@bs.module] external leftPad : (string, int) => string = "./leftPad";
@@ -375,7 +375,7 @@ Import ES6 default compiled from Babel:
 external studentName: string = "default" [@@bs.module "./student"]
 ```
 
-Reason syntax:
+
 
 ```reason
 [@bs.module "./student"] external studentName : string = "default";
@@ -387,7 +387,7 @@ Reason syntax:
 let default = "Bob"
 ```
 
-Reason syntax:
+
 
 ```reason
 let default = "Bob";
@@ -401,7 +401,7 @@ Final escape hatch converter. Do not abuse.
 external myShadyConversion : foo -> bar = "%identity"
 ```
 
-Reason syntax:
+
 
 ```reason
 external myShadyConversion : foo => bar = "%identity";

--- a/docs/interop-misc.md
+++ b/docs/interop-misc.md
@@ -42,7 +42,7 @@ let handleData = function [@bs.open]
 (* val handleData : 'a -> int option *)
 ```
 
-Reason syntax:
+
 
 ```reason
 let handleData = [@bs.open] (

--- a/docs/interop-overview.md
+++ b/docs/interop-overview.md
@@ -24,7 +24,7 @@ Major data structures in BuckleScript **map over cleanly to JS**. For example, a
 let messages = [| "hello"; "world"; "how"; "are"; "you" |]
 ```
 
-Reason syntax:
+
 
 ```reason
 let messages = [|"hello", "world", "how", "are", "you"|];

--- a/docs/intro-to-external.md
+++ b/docs/intro-to-external.md
@@ -10,7 +10,7 @@ Many parts of the interop system uses a concept called `external`, so we'll spec
 external myCFunction : int -> string = "theCFunctionName"
 ```
 
-Reason syntax:
+
 
 ```reason
 external myCFunction : int => string = "theCFunctionName";
@@ -32,7 +32,7 @@ One external worth mentioning is the following one:
 external myShadyConversion : foo -> bar = "%identity"
 ```
 
-Reason syntax:
+
 
 ```reason
 external myShadyConversion : foo => bar = "%identity";

--- a/docs/json.md
+++ b/docs/json.md
@@ -19,7 +19,7 @@ external parseIntoMyData : string -> data = "parse" [@@bs.scope "JSON"][@@bs.val
 let result = parseIntoMyData "{\"name\": \"Luke\"}"
 ```
 
-Reason syntax:
+
 
 ```reason
 type data = {. "name": string};

--- a/docs/nodejs-special-variables.md
+++ b/docs/nodejs-special-variables.md
@@ -13,7 +13,7 @@ let _module : Node.node_module option = [%bs.node _module]
 let require : Node.node_require option = [%bs.node require]
 ```
 
-Reason syntax:
+
 
 ```reason
 let dirname: option(string) = [%bs.node __dirname];

--- a/docs/null-undefined-option.md
+++ b/docs/null-undefined-option.md
@@ -16,7 +16,7 @@ If you're receiving, for example, a JS string that can also be null, type it as:
 let theJsValue: string Js.Nullable.t = /* the value you've gotten here */
 ```
 
-Reason syntax:
+
 
 ```reason
 let theJsValue: Js.Nullable.t(string) = /* the value you've gotten here */
@@ -28,7 +28,7 @@ To create a nullable string, do:
 let nullableString: string Js.Nullable.t = Js.Nullable.return "hello"
 ```
 
-Reason syntax:
+
 
 ```reason
 let nullableString: Js.Nullable.t(string) = Js.Nullable.return("hello");
@@ -53,7 +53,7 @@ type element
 external getElementById : string -> element option = "getElementById" [@@bs.val][@@bs.scope "document"][@@bs.return nullable]
 ```
 
-Reason syntax:
+
 
 ```reason
 type element;

--- a/docs/object.md
+++ b/docs/object.md
@@ -25,7 +25,7 @@ let myMap = Js.Dict.empty ()
 let _ = Js.Dict.set myMap "Allison" 10
 ```
 
-Reason syntax:
+
 
 ```reason
 let myMap = Js.Dict.empty();
@@ -64,7 +64,7 @@ type person = <
 external john : person = "john" [@@bs.val]
 ```
 
-Reason syntax:
+
 
 ```reason
 type person = Js.t({
@@ -98,7 +98,7 @@ external john: person = "john" [@@bs.val]
 let _ = john##age #= 99
 ```
 
-Reason syntax:
+
 
 ```reason
 type person = {. [@bs.set] "age": int};
@@ -120,7 +120,7 @@ external john: person = "john" [@@bs.val]
 let _ = john##say "hey" "jude"
 ```
 
-Reason syntax:
+
 
 ```reason
 type person = {. [@bs.meth] "say": (string, string) => unit};
@@ -139,7 +139,7 @@ let jude = talkTo "jude"
 let paul = talkTo "paul"
 ```
 
-Reason syntax:
+
 
 ```reason
 /* wrong */
@@ -163,7 +163,7 @@ let bucklescript = [%bs.obj {
 let name = bucklescript##info##author
 ```
 
-Reason syntax:
+
 
 ```reason
 let bucklescript = [%bs.obj {
@@ -177,7 +177,7 @@ Because object values are used often, Reason gives it a nicer sugar. `[%bs.obj {
 
 **Note**: there's no syntax sugar for creating an empty object in OCaml nor Reason (aka this doesn't work: `[@bs.obj {}]`. Please use `Js.Obj.empty()` for that purpose.
 
-The created object will have an inferred type, no type declaration needed! The above example will infer as `< info: < author: string > Js.t > Js.t`. Reason syntax: `{. "info": {. "author": string}}`.
+The created object will have an inferred type, no type declaration needed! The above example will infer as `< info: < author: string > Js.t > Js.t`.  `{. "info": {. "author": string}}`.
 
 **Note**: since the value has its type inferred, **don't** accidentally do this:
 
@@ -186,7 +186,7 @@ type person = <age: int> Js.t
 let jane = [%bs.obj {age = "hi"}]
 ```
 
-Reason syntax:
+
 
 ```reason
 type person = {. "age": int};
@@ -210,7 +210,7 @@ let high: int = c1##high
 let low: int Js.undefined = c1##low
 ```
 
-Reason syntax:
+
 
 ```reason
 [@bs.obj] external makeConfig : (~high: int, ~low: int=?, unit) => _ = "";
@@ -251,7 +251,7 @@ external makeIOConfig :
 let config = makeIOConfig ~cwd:"." ()
 ```
 
-Reason syntax:
+
 
 ```reason
 [@bs.obj]
@@ -306,7 +306,7 @@ f##draw__int 3 4
 f##draw__float 3.2 4.5
 ```
 
-Reason syntax:
+
 
 ```reason
 f##draw__int(3, 4);
@@ -347,7 +347,7 @@ let _ = set i32arr 0 42
 let _ = Js.log (get i32arr 0)
 ```
 
-Reason syntax:
+
 
 ```reason
 type t;
@@ -381,7 +381,7 @@ external myTextArea: textarea = "" [@@bs.val]
 let _ = setName myTextArea "asd"
 ```
 
-Reason syntax:
+
 
 ```reason
 type textarea;

--- a/website/siteConfig.js
+++ b/website/siteConfig.js
@@ -84,6 +84,7 @@ const siteConfig = {
     { search: true },
     { href: "https://github.com/bucklescript/bucklescript", label: "GitHub" },
   ],
+  scripts: ["/js/toggleSyntaxButton.js"],
   users,
   examples,
   headerIcon: "img/logos/bucklescript_small.svg",

--- a/website/static/css/custom.css
+++ b/website/static/css/custom.css
@@ -117,26 +117,23 @@
   padding: 10px;
 }
 
-.toggleSyntaxButton:hover,
-.syntax__reason .toggleSyntaxButton-ocaml {
+.toggleSyntaxButton:hover {
   background: none;
   color: #a1639f;
 }
 
-.toggleSyntaxButton-ocaml,
+.syntax__ocaml .toggleSyntaxButton-ocaml,
 .syntax__reason .toggleSyntaxButton-reason {
   background: #a1639f;
   color: #fff;
 }
 
-.hljs.reason {
+.hljs.reason,
+.hljs.ocaml {
   display: none;
 }
 
-.syntax__reason .hljs.ocaml {
-  display: none;
-}
-
-.syntax__reason .hljs.reason {
+.syntax__reason .hljs.reason,
+.syntax__ocaml .hljs.ocaml {
   display: block;
 }

--- a/website/static/css/custom.css
+++ b/website/static/css/custom.css
@@ -101,3 +101,28 @@
 }
 
 /* end override */
+
+.toggleSyntaxButton {
+  display: block;
+  position: absolute;
+  top: 96px;
+  right: 80px;
+  cursor: pointer;
+  z-index: 100;
+  font-size: 10px;
+}
+
+.hljs.reason,
+.toggleSyntaxButton-reason {
+  display: none;
+}
+
+.syntax__reason .hljs.ocaml,
+.syntax__reason .toggleSyntaxButton-ocaml {
+  display: none;
+}
+
+.syntax__reason .hljs.reason,
+.syntax__reason .toggleSyntaxButton-reason  {
+  display: block;
+}

--- a/website/static/css/custom.css
+++ b/website/static/css/custom.css
@@ -103,26 +103,40 @@
 /* end override */
 
 .toggleSyntaxButton {
-  display: block;
+  display: flex;
   position: absolute;
   top: 96px;
   right: 80px;
+  padding: 0;
   cursor: pointer;
   z-index: 100;
   font-size: 10px;
 }
 
-.hljs.reason,
-.toggleSyntaxButton-reason {
-  display: none;
+.toggleSyntaxButton span {
+  padding: 10px;
 }
 
-.syntax__reason .hljs.ocaml,
+.toggleSyntaxButton:hover,
 .syntax__reason .toggleSyntaxButton-ocaml {
+  background: none;
+  color: #a1639f;
+}
+
+.toggleSyntaxButton-ocaml,
+.syntax__reason .toggleSyntaxButton-reason {
+  background: #a1639f;
+  color: #fff;
+}
+
+.hljs.reason {
   display: none;
 }
 
-.syntax__reason .hljs.reason,
-.syntax__reason .toggleSyntaxButton-reason  {
+.syntax__reason .hljs.ocaml {
+  display: none;
+}
+
+.syntax__reason .hljs.reason {
   display: block;
 }

--- a/website/static/js/toggleSyntaxButton.js
+++ b/website/static/js/toggleSyntaxButton.js
@@ -1,5 +1,6 @@
 document.addEventListener('DOMContentLoaded', () => {
-  const CLASS_REASON = 'syntax__reason'
+  const SYNTAXES = ['reason', 'ocaml']
+  const CLASS_PREFIX = 'syntax__'
   const $toggleSyntaxButton = document.createElement('button')
 
   $toggleSyntaxButton.classList.add('button', 'toggleSyntaxButton')
@@ -7,10 +8,20 @@ document.addEventListener('DOMContentLoaded', () => {
     <span class="toggleSyntaxButton-reason">Reason</span>
     <span class="toggleSyntaxButton-ocaml">OCaml</span>
   `
-
   document.body.appendChild($toggleSyntaxButton)
 
+  let currentSyntax
+  let setCurrentSyntax = (syntax = SYNTAXES[0]) => {
+    document.body.classList.remove(`${CLASS_PREFIX}${currentSyntax}`)
+    document.body.classList.add(`${CLASS_PREFIX}${syntax}`)
+
+    currentSyntax = syntax
+    localStorage.setItem('syntax', currentSyntax)
+  }
+
+  setCurrentSyntax(localStorage.getItem('syntax', currentSyntax))
+
   $toggleSyntaxButton.addEventListener('click', () => {
-    document.body.classList.toggle(CLASS_REASON)
+    setCurrentSyntax(currentSyntax == SYNTAXES[0] ? SYNTAXES[1] : SYNTAXES[0])
   })
 })

--- a/website/static/js/toggleSyntaxButton.js
+++ b/website/static/js/toggleSyntaxButton.js
@@ -1,0 +1,16 @@
+document.addEventListener('DOMContentLoaded', () => {
+  const CLASS_REASON = 'syntax__reason'
+  const $toggleSyntaxButton = document.createElement('button')
+
+  $toggleSyntaxButton.classList.add('button', 'toggleSyntaxButton')
+  $toggleSyntaxButton.innerHTML = `
+    <span class="toggleSyntaxButton-reason">Reason</span>
+    <span class="toggleSyntaxButton-ocaml">OCaml</span>
+  `
+
+  document.body.appendChild($toggleSyntaxButton)
+
+  $toggleSyntaxButton.addEventListener('click', () => {
+    document.body.classList.toggle(CLASS_REASON)
+  })
+})


### PR DESCRIPTION
Hi! 

Most of the times you only need one type of syntax and it would be pretty nice to hide one that you don't need.

This is a pretty straightforward implementation of this feature. If you have some suggestions on how to improve it, I'll gladly make changes in this PR.