### PR TITLE
Link to object method in function section broken.

### DIFF
--- a/docs/object.md
+++ b/docs/object.md
@@ -271,4 +271,4 @@ joe |. ageSet(21)
 
 ### Methods
 
-You can attach arbitrary methods onto a type (_any_ type, as a matter of fact. Not just `bs.deriving abstract` record types). See [Object Method](/function.html#object-method) in the later function section.
+You can attach arbitrary methods onto a type (_any_ type, as a matter of fact. Not just `bs.deriving abstract` record types). See [Object Method](/docs/function.html#object-method) in the later function section.

--- a/docs/object.md
+++ b/docs/object.md
@@ -214,7 +214,7 @@ Reason syntax:
 let twenty = age(joe)
 ```
 
-Alternatively, you can use the [Fast Pipe](/fast-pipe.md) feature in a later section for a nicer-looking access syntax:
+Alternatively, you can use the [Fast Pipe](/docs/fast-pipe.html) feature in a later section for a nicer-looking access syntax:
 
 ```ocaml
 let twenty = joe |. age

--- a/docs/object.md
+++ b/docs/object.md
@@ -271,4 +271,4 @@ joe |. ageSet(21)
 
 ### Methods
 
-You can attach arbitrary methods onto a type (_any_ type, as a matter of fact. Not just `bs.deriving abstract` record types). See [Object Method](/function.md#object-method) in the function section later.
+You can attach arbitrary methods onto a type (_any_ type, as a matter of fact. Not just `bs.deriving abstract` record types). See [Object Method](/function.html#object-method) in the later function section.


### PR DESCRIPTION
In the new [Object](https://bucklescript.github.io/docs/en/object.html) section the link to *Object Method* sub-section in Function section and link to *Fast Pipe* section is broken.

Currently the link has href attribute `/function.md#object-method`, changing it to`/docs/function.html#object-method` fixes the issue