### PR TITLE
Sys.argv, Sys.max_array_length, Sys.max_string_length are working

### DIFF
--- a/docs/difference-from-native-ocaml.md
+++ b/docs/difference-from-native-ocaml.md
@@ -46,10 +46,6 @@ BuckleScript uses the same algorithm as native OCaml, but the output is differen
 
 Not supported yet.
 
-## Sys.argv, Sys.max_array_length, Sys.max_string_length
-
-Command line arguments are always empty. This might be fixed in the future. `Sys.max_array_length` and `Sys.max_string_length` will be the same as `max_int`, but it might be respected.
-
 ## Unsupported IO Primitives
 
 Because of the JS environment limitation, `Pervasives.stdin` is not supported but both `Pervasives.stdout` and `Pervasives.stderr` are.


### PR DESCRIPTION
I tried this

```re
Js.log(Sys.argv);

Js.log(Sys.max_array_length);

Js.log(Sys.max_string_length);
```

(compiled to)

```js
// Generated by BUCKLESCRIPT VERSION 3.1.5, PLEASE EDIT WITH CARE
'use strict';

var Sys = require("bs-platform/lib/js/sys.js");

console.log(Sys.argv);

console.log(Sys.max_array_length);

console.log(Sys.max_string_length);

/*  Not a pure module */

```

And got this

```
❯ ./index.js lol
[ '/Users/MoOx/.nvs/node/8.11.1/x64/bin/node',
  '/Users/MoOx/Sync/Development/git-init/index.js',
  'lol' ]
2147483647
2147483647
```

(index.js import my Module.re via .bs.js suffix)