### PR TITLE
Make links more prominent in overview page

### DIFF
--- a/docs/stdlib-overview.md
+++ b/docs/stdlib-overview.md
@@ -2,12 +2,17 @@
 title: Overview
 ---
 
-BuckleScript is mostly just OCaml, so they share the same standard library. The OCaml syntax version is [here](https://caml.inria.fr/pub/docs/manual-ocaml-4.02/stdlib.html). The Reason syntax version is [here](https://reasonml.github.io/api/index.html).
+BuckleScript is mostly just OCaml, so they share the same standard library:
+
+* [OCaml syntax standard library documentation](https://caml.inria.fr/pub/docs/manual-ocaml-4.02/stdlib.html).
+* [Reason syntax standard library documentation](https://reasonml.github.io/api/index.html).
 
 **Note** that BuckleScript is currently at OCaml v4.02.3. We will upgrade to a newer OCaml later on.
 
-In addition, we provide a few extra modules, documented [here](https://bucklescript.github.io/bucklescript/api/):
+In addition, we provide a few extra modules:
 
-- `Dom`: contains DOM types. The DOM is very hard to bind to, so we've decided to only keep the types in the stdlib and let users bind to the subset of DOM they need downstream.
-- `Node`: for node-specific APIs. Experimental; contribution welcome!
-- `Js`: all the familiar JS APIs and modules are here! E.g. if you want to use the [JS Array API](https://bucklescript.github.io/bucklescript/api/Js.Array.html) over the [OCaml Array API](https://caml.inria.fr/pub/docs/manual-ocaml-4.02/libref/Array.html) because you're more familiar with the former, go ahead.
+- [Dom](https://bucklescript.github.io/bucklescript/api/Dom.html): contains DOM types. The DOM is very hard to bind to, so we've decided to only keep the types in the stdlib and let users bind to the subset of DOM they need downstream.
+- [Node](https://bucklescript.github.io/bucklescript/api/Node.html): for node-specific APIs. Experimental; contribution welcome!
+- [Js](https://bucklescript.github.io/bucklescript/api/Js.html): all the familiar JS APIs and modules are here! E.g. if you want to use the [JS Array API](https://bucklescript.github.io/bucklescript/api/Js.Array.html) over the [OCaml Array API](https://caml.inria.fr/pub/docs/manual-ocaml-4.02/libref/Array.html) because you're more familiar with the former, go ahead.
+
+The full index of modules is available at: <https://bucklescript.github.io/bucklescript/api/>


### PR DESCRIPTION
I had a hard time finding the documentation for the BuckleScript modules so this PR links directly to the modules and makes other links more prominent. I tried to make the link content more useful than just linking with the text "here".