### PR TITLE
Update old object API section title so it's less confusing

### DIFF
--- a/docs/object-deprecated.md
+++ b/docs/object-deprecated.md
@@ -1,5 +1,5 @@
 ---
-title: Object 
+title: Object (old API)
 ---
 
 **Note**: this is the old API for binding to JS objects, kept for backward-compatibility. Please check the previous page for the current way of doing it.


### PR DESCRIPTION
Currently both new and old object API as enlisted with the same title which makes it seem duplicated at first glance.