### PR TITLE
Minor Grammar Fix

### DIFF
--- a/docs/common-data-types.md
+++ b/docs/common-data-types.md
@@ -28,7 +28,7 @@ Js.log "你好"
 Js.log("你好")
 ```
 
-It'll compile to the follow JS:
+It'll compile to the following JS:
 
 ```js
 console.log("\xe4\xbd\xa0\xe5\xa5\xbd");


### PR DESCRIPTION
Very minor grammar fix I noticed when reading the docs.

From: 
`It'll compile to the follow JS:`

To:
`It'll compile to the following JS:`