### PR TITLE
Add troubleshooting tips for EACCESS error

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -70,3 +70,21 @@ make world
 At the end, you should have a binary called `bsc.exe` under `jscomp/bin` directory, which you can add to your `$PATH`. You can also set an environment variable pointing to the standard library, e.g. `BSC_LIB=/path/to/jscomp/stdlib`, for ease of use.
 
 **Warning:** the built compiler is not relocatable out of box, don’t move it around unless you know what you're doing!
+
+## Troubleshooting
+
+### Permission denied errors
+
+Under some conditions, the global installation of `bs-platform` will result in npm errors, typically indicating `Error: EACCES: permission denied`. Here are some methods for resolving this problem.
+
+#### Manually change npm’s default directory
+
+Changing where NPM stores the package files may help, see the [second solution](https://docs.npmjs.com/resolving-eacces-permissions-errors-when-installing-packages-globally) on the [docs.npmjs.com](https://docs.npmjs.com/) site.
+
+#### Enable the `unsafe-perm` npm option
+
+While using `unsafe-perm` does have some drawbacks, it easily resolves the permissions issue. When the changing the default directory does not work, then this may be the next best option.
+
+```sh
+npm install -g bs-platform --unsafe-perm
+```


### PR DESCRIPTION
Turns out that this permission denied error can come up in many different
cases, not just FreeBSD or Docker, but also Ubuntu. Also seems that there
are at least two solutions, one of which may or may not resolve the issue,
but has worked for some. The second solution almost certainly works, but has
some drawback in terms of security implications.

Relates to BuckleScript/bucklescript issues 2051 and 3028.