### PR TITLE
document BS_WATCHNOCLEAR to suppress console.clear() in watch mode

### DIFF
--- a/docs/build-overview.md
+++ b/docs/build-overview.md
@@ -36,6 +36,8 @@ Add `-w` to keep the built-in watcher running. Any new file change will be picke
 
 **Note**: third-party libraries (in `node_modules`) aren't watched, as doing so may exceed the node.js watcher count limit. If you're doing quick and dirty modifications inside `node_modules`, you have to do `bsb -clean-world -make-world` to rebuild them.
 
+**Note 2**: The watcher clears the screen with each rebuild. To suppress this, set the environment variable BS_WATCHNOCLEAR to some truthy value: `BS_WATCHNOCLEAR=1 npm start`
+
 **To build only yourself**, use `bsb -make`.
 
 `bsb -help` to see all the available options.


### PR DESCRIPTION
related to https://github.com/BuckleScript/bucklescript/pull/3402

I'm not sure this chunk of documentation is exposed on the website
though -- can a user even navigate to this page from the home page?