### PR TITLE
Stop quickly toggling from selecting button's text

### DIFF
--- a/website/static/css/custom.css
+++ b/website/static/css/custom.css
@@ -14,6 +14,9 @@
 
 .toggleSyntaxButton span {
   padding: 10px;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  user-select: none;
 }
 
 .syntax__ocaml .toggleSyntaxButton-ocaml,


### PR DESCRIPTION
When mouse-clicking to quickly toggle the syntax flavour using the button, the button's text would become selected.

https://caniuse.com/#feat=user-select-none

