### PR TITLE
rename fast pipe to pipe first

### DIFF
--- a/docs/function.md
+++ b/docs/function.md
@@ -85,7 +85,7 @@ In a `bs.send`, the object is always the first argument. Actual arguments of the
 
 ### Chaining
 
-Ever used `foo().bar().baz()` chaining ("fluent api") in JS OOP? We can model that in BuckleScript too, through the fast pipe operator described in the next section.
+Ever used `foo().bar().baz()` chaining ("fluent api") in JS OOP? We can model that in BuckleScript too, through the Pipe First operator described in the next section.
 
 ## Variadic Function Arguments
 

--- a/docs/object.md
+++ b/docs/object.md
@@ -202,7 +202,7 @@ let twenty = ageGet joe
 let twenty = ageGet(joe)
 ```
 
-Alternatively, you can use the [Fast Pipe](fast-pipe.md) feature in a later section for a nicer-looking access syntax:
+Alternatively, you can use the [Pipe First](pipe-first.md) feature in a later section for a nicer-looking access syntax:
 
 ```ocaml
 let twenty = joe |. ageGet
@@ -245,7 +245,7 @@ let joe = person(~name="Joe", ~age=20, ~job="teacher");
 ageSet(joe, 21);
 ```
 
-Alternatively, with the fast pipe syntax:
+Alternatively, with the Pipe First syntax:
 
 ```ocaml
 joe |. ageSet 21

--- a/docs/pipe-first.md
+++ b/docs/pipe-first.md
@@ -1,5 +1,5 @@
 ---
-title: Fast Pipe
+title: Pipe First
 ---
 
 BuckleScript has a special `|.` (or `->` for Reason) pipe syntax for dealing with various situations. This operator has many uses.

--- a/website/blog/2018-05-21-release-3-1-0.md
+++ b/website/blog/2018-05-21-release-3-1-0.md
@@ -28,9 +28,9 @@ Please see [Better Data Structures Printing (Debug Mode)](/docs/en/better-data-s
 
 We've further polished our new way of binding to JS objects. The record fields of a `bs.deriving abstract` can now accept functions.
 
-## Fast Pipe Improvement
+## Pipe First Improvement
 
-[Fast pipe](/docs/en/fast-pipe.html) now supports piping into variant tags!
+[Pipe First](/docs/en/pipe-first.html) now supports piping into variant tags!
 
 ```ocaml
 let result = name |. preprocess |. Some

--- a/website/i18n/en.json
+++ b/website/i18n/en.json
@@ -65,9 +65,6 @@
       "extended-compiler-options": {
         "title": "Extended Compiler Options"
       },
-      "fast-pipe": {
-        "title": "Fast Pipe"
-      },
       "function": {
         "title": "Function"
       },
@@ -115,6 +112,9 @@
       },
       "object": {
         "title": "Object"
+      },
+      "pipe-first": {
+        "title": "Pipe First"
       },
       "playground": {
         "title": "Playground"

--- a/website/sidebars.json
+++ b/website/sidebars.json
@@ -22,7 +22,7 @@
       "regular-expression",
       "exceptions",
       "json",
-      "fast-pipe",
+      "pipe-first",
       "generate-converters-accessors",
       "better-data-structures-printing-debug-mode",
       "nodejs-special-variables",


### PR DESCRIPTION
Aligns the naming with the Reason documentation