### PR TITLE
Clarify visibility of bs-dev-dependencies modules

### DIFF
--- a/docs/build-configuration.md
+++ b/docs/build-configuration.md
@@ -63,7 +63,9 @@ You can mark your directories as dev-only (for e.g. tests). These won't be built
 
 ## bs-dependencies, bs-dev-dependencies
 
-List of BuckleScript/Reason dependencies. Just like `package.json`'s dependencies, they'll be searched in `node_modules`.
+List of BuckleScript/Reason dependencies. Just like `package.json`'s dependencies, they'll be searched in `node_modules`. 
+
+Note that only sources marked with `"type":"dev"` will be able to resolve modules from `bs-dev-dependencies`.
 
 ## reason, refmt
 


### PR DESCRIPTION
Readers following the top search result for "unit testing in ReasonML" will be directed to a [blog post with out of date instructions](https://jaketrent.com/post/unit-testing-in-reasonml/).

Per https://github.com/BuckleScript/bucklescript/issues/1490, sources need to be marked `dev` in order to resolve dev dependencies. This change clarifies that in documentation. 
