### PR TITLE
Reduce jump when switching language

### DIFF
--- a/website/pages/en/index.js
+++ b/website/pages/en/index.js
@@ -94,8 +94,12 @@ class HomeSplash extends React.Component {
             <div className="homeWrapperInner">
               <div className="homeTagLine">{siteConfig.tagline}</div>
               <div className="homeCodeSnippet">
-                <MarkdownBlock>{codeExampleReason}</MarkdownBlock>
-                <MarkdownBlock>{codeExample}</MarkdownBlock>
+                <div className="homeCodeSnippet-reason">
+                  <MarkdownBlock>{codeExampleReason}</MarkdownBlock>
+                </div>
+                <div className="homeCodeSnippet-ocaml">
+                  <MarkdownBlock>{codeExample}</MarkdownBlock>
+                </div>
               </div>
             </div>
 

--- a/website/static/css/custom.css
+++ b/website/static/css/custom.css
@@ -30,6 +30,10 @@
 .syntax__ocaml .hljs.language-reason {
   display: none;
 }
+.syntax__reason .homeCodeSnippet-ocaml,
+.syntax__ocaml .homeCodeSnippet-reason {
+  display: none;
+}
 
 /* end syntax toggler */
 
@@ -56,7 +60,6 @@
   max-height: 70px;
   width: 70px;
 }
-
 
 /* overrides. Most of these should be upstreamed into docusaurus */
 


### PR DESCRIPTION
This should remove the vertical jump when switching between OCaml/Reason language.

Before:

![2019-07-19 08 52 28](https://user-images.githubusercontent.com/5595092/61515769-b3d1b680-aa03-11e9-83ae-dd5d794599e6.gif)

After:

![2019-07-19 08 53 09](https://user-images.githubusercontent.com/5595092/61515785-b92f0100-aa03-11e9-9b85-735226c5fb35.gif)
